### PR TITLE
Add HTML demo using Blockly

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,22 @@
 # ML-MAZE
-ML-MAZE
+
+Ce projet propose une activité pédagogique pour apprendre aux élèves (11–14 ans) comment un algorithme peut naviguer un labyrinthe.
+
+## Objectif
+
+* Expérimenter la différence entre une programmation statique par règles et un apprentissage automatique (Q-learning) pour résoudre un labyrinthe.
+
+## Utilisation
+
+1. Lancez `maze_ml_activity.py` pour générer un labyrinthe aléatoire.
+2. Observez la solution par règles (recherche de chemin) puis par un agent à apprentissage.
+
+```bash
+python maze_ml_activity.py
+```
+
+Ou ouvrez `maze_activity.html` dans votre navigateur pour la version Blockly interactive.
+
+## Notes pédagogiques
+
+Au début, l'élève peut essayer de définir lui-même une séquence d'actions adaptée à un labyrinthe fixe. Ensuite, le labyrinthe change à chaque exécution et l'élève constate que sa solution doit généraliser. C'est l'occasion d'introduire l'apprentissage automatique.

--- a/maze_activity.html
+++ b/maze_activity.html
@@ -1,0 +1,312 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8"/>
+  <title>Maze Runner: Rules vs. Q-Learning</title>
+  <script src="https://unpkg.com/blockly/blockly.min.js"></script>
+  <style>
+    body { display: flex; height: 100vh; margin: 0; font-family: sans-serif; }
+    #blocklyDiv { width: 35%; height: 100%; }
+    #rightPanel { flex: 1; display: flex; flex-direction: column; }
+    #mazeCanvas { flex: 1; background: #eee; }
+    #controls { padding: 10px; text-align: center; }
+    button { margin: 0 4px; padding: 6px 10px; font-size: 0.9em; }
+  </style>
+</head>
+<body>
+
+  <!-- Blockly workspace -->
+  <div id="blocklyDiv"></div>
+
+  <!-- Maze & controls -->
+  <div id="rightPanel">
+    <canvas id="mazeCanvas"></canvas>
+    <div id="controls">
+      <button id="bfsBtn">Solve BFS</button>
+      <button id="trainBtn">Train AI</button>
+      <button id="startBtn">Start</button>
+      <button id="stepBtn">Step</button>
+      <button id="stopBtn">Stop</button>
+      <button id="resetBtn">Reset</button>
+      <button id="modeBtn">Mode: Rules</button>
+    </div>
+  </div>
+
+  <!-- Toolbox -->
+  <xml id="toolbox" style="display:none">
+    <category name="Events" colour="#FFD700">
+      <block type="on_start"></block>
+    </category>
+    <category name="Control" colour="#FF8C1A">
+      <block type="controls_if"></block>
+    </category>
+    <category name="Movement" colour="#5C81A6">
+      <block type="move_forward"></block>
+      <block type="turn_left"></block>
+      <block type="turn_right"></block>
+    </category>
+    <category name="Sensors" colour="#A65C81">
+      <block type="wall_ahead"></block>
+    </category>
+  </xml>
+
+  <script>
+  Blockly.Workspace.prototype.getAllVariables = function() {
+    return this.getVariableMap().getAllVariables();
+  };
+
+  Blockly.Blocks['on_start'] = {
+    init() {
+      this.appendDummyInput().appendField('on start');
+      this.appendStatementInput('DO').appendField('do');
+      this.setColour(120);
+    }
+  };
+  Blockly.Blocks['move_forward'] = {
+    init() {
+      this.appendDummyInput().appendField('move forward');
+      this.setColour(160);
+      this.setPreviousStatement(true);
+      this.setNextStatement(true);
+    }
+  };
+  Blockly.Blocks['turn_left'] = {
+    init() {
+      this.appendDummyInput().appendField('turn left');
+      this.setColour(160);
+      this.setPreviousStatement(true);
+      this.setNextStatement(true);
+    }
+  };
+  Blockly.Blocks['turn_right'] = {
+    init() {
+      this.appendDummyInput().appendField('turn right');
+      this.setColour(160);
+      this.setPreviousStatement(true);
+      this.setNextStatement(true);
+    }
+  };
+  Blockly.Blocks['wall_ahead'] = {
+    init() {
+      this.appendDummyInput().appendField('wall ahead?');
+      this.setColour(210);
+      this.setOutput(true,'Boolean');
+    }
+  };
+  Blockly.Blocks['controls_if'] = Blockly.Blocks['controls_if'];
+
+  const workspace = Blockly.inject('blocklyDiv', {
+    toolbox: document.getElementById('toolbox'),
+    scrollbars: true, trashcan: true
+  });
+
+  class Maze {
+    constructor(cols, rows, size) {
+      this.cols = cols; this.rows = rows; this.size = size;
+      this.canvas = document.getElementById('mazeCanvas');
+      this.ctx = this.canvas.getContext('2d');
+      this.canvas.width  = cols * size;
+      this.canvas.height = rows * size;
+      this._buildGrid();
+      this.reset();
+    }
+    _buildGrid() {
+      this.grid = Array(this.rows).fill().map(()=>Array(this.cols).fill(0));
+      for(let y=0;y<this.rows;y++){
+        for(let x=0;x<this.cols;x++){
+          if(x===0||y===0||x===this.cols-1||y===this.rows-1)
+            this.grid[y][x] = 1;
+          else if(Math.random()<0.2)
+            this.grid[y][x] = 1;
+        }
+      }
+      this.grid[1][1] = 'S';
+      this.grid[this.rows-2][this.cols-2] = 'G';
+    }
+    reset() { this.agent = { x:1, y:1, dir:0 }; }
+    draw(path=[]) {
+      const {ctx,size,grid} = this;
+      ctx.clearRect(0,0,this.canvas.width,this.canvas.height);
+      for(let y=0;y<grid.length;y++){
+        for(let x=0;x<grid[0].length;x++){
+          const v = grid[y][x];
+          ctx.fillStyle = v===1?'#000':v==='S'?'#0f0':v==='G'?'#f00':'#fff';
+          ctx.fillRect(x*size,y*size,size,size);
+          ctx.strokeRect(x*size,y*size,size,size);
+        }
+      }
+      if(path.length){
+        ctx.fillStyle='#ff0';
+        for(const p of path){
+          ctx.fillRect(p.x*size+10,p.y*size+10,size-20,size-20);
+        }
+      }
+      ctx.fillStyle='#00f';
+      ctx.fillRect(this.agent.x*size+4,this.agent.y*size+4,size-8,size-8);
+    }
+    step(action) {
+      if(action===1) this.agent.dir=(this.agent.dir+3)%4;
+      else if(action===2) this.agent.dir=(this.agent.dir+1)%4;
+      else if(action===0) {
+        const dx=[1,0,-1,0][this.agent.dir],
+              dy=[0,1,0,-1][this.agent.dir],
+              nx=this.agent.x+dx, ny=this.agent.y+dy;
+        if(this.grid[ny][nx]!==1){
+          this.agent.x=nx; this.agent.y=ny;
+        }
+      }
+      return this.grid[this.agent.y][this.agent.x]==='G';
+    }
+    getSensors() {
+      const dx=[1,0,-1,0][this.agent.dir],
+            dy=[0,1,0,-1][this.agent.dir],
+            nx=this.agent.x+dx, ny=this.agent.y+dy;
+      return { wallAhead: this.grid[ny][nx]===1 };
+    }
+    bfsPath(){
+      const start={x:1,y:1}, goal={x:this.cols-2,y:this.rows-2};
+      const queue=[[start,[start]]];
+      const visited=new Set([start.x+','+start.y]);
+      const dirs=[[1,0],[-1,0],[0,1],[0,-1]];
+      while(queue.length){
+        const [node,path]=queue.shift();
+        if(node.x===goal.x && node.y===goal.y) return path;
+        for(const [dx,dy] of dirs){
+          const nx=node.x+dx, ny=node.y+dy;
+          const key=nx+','+ny;
+          if(!visited.has(key) && this.grid[ny][nx]!==1){
+            visited.add(key);
+            queue.push([{x:nx,y:ny},path.concat({x:nx,y:ny})]);
+          }
+        }
+      }
+      return [];
+    }
+  }
+
+  class RuleAgent {
+    constructor(ws) { this.ws = ws; this.program = []; this.pc = 0; }
+    reset() {
+      const hats = this.ws.getBlocksByType('on_start', false);
+      this.program = [];
+      if (hats.length) {
+        let b = hats[0].getInputTargetBlock('DO');
+        while (b) { this.program.push(b); b = b.getNextBlock(); }
+      }
+      this.pc = 0;
+    }
+    step(sensors) {
+      if (this.pc >= this.program.length) return null;
+      const block = this.program[this.pc++];
+      return this._exec(block, sensors);
+    }
+    done() { return this.pc >= this.program.length; }
+    _exec(block, sensors) {
+      switch (block.type) {
+        case 'move_forward': return 0;
+        case 'turn_left':    return 1;
+        case 'turn_right':   return 2;
+        case 'controls_if':
+          const cond = block.getInputTargetBlock('IF0');
+          if ( this._evalCond(cond, sensors) ) {
+            let inner = block.getInputTargetBlock('DO0');
+            let last = null;
+            while (inner) { last = this._exec(inner, sensors); inner = inner.getNextBlock(); }
+            return last;
+          }
+          return null;
+        default:
+          return null;
+      }
+    }
+    _evalCond(block, sensors) {
+      if (!block) return false;
+      switch (block.type) {
+        case 'logic_boolean':
+          return block.getFieldValue('BOOL')==='TRUE';
+        case 'wall_ahead':
+          return sensors.wallAhead;
+        default:
+          return false;
+      }
+    }
+  }
+
+  class QAgent {
+    constructor(actions, a=0.1, g=0.9, e=0.2){ this.actions=actions; this.a=a; this.g=g; this.e=e; this.q={}; }
+    key(s,a){return `${s}|${a}`;}
+    get(s,a){return this.q[this.key(s,a)]||0;}
+    choose(s){
+      if(Math.random()<this.e)
+        return this.actions[Math.floor(Math.random()*this.actions.length)];
+      const qs=this.actions.map(a=>this.get(s,a)), m=Math.max(...qs);
+      return this.actions[qs.indexOf(m)];
+    }
+    learn(s,a,r,s2){
+      const old=this.get(s,a), best=Math.max(...this.actions.map(x=>this.get(s2,x)));
+      this.q[this.key(s,a)] = old + this.a*(r + this.g*best - old);
+    }
+    train(env, episodes=500){
+      for(let e=0;e<episodes;e++){
+        env.reset();
+        let state=`${env.agent.x},${env.agent.y},${env.agent.dir}`;
+        let done=false,steps=0;
+        while(!done && steps<200){
+          const a=this.choose(state), reached=env.step(a);
+          const ns=`${env.agent.x},${env.agent.y},${env.agent.dir}`;
+          const r=reached?1:-0.01;
+          this.learn(state,a,r,ns);
+          state=ns; steps++; done=reached;
+        }
+      }
+    }
+  }
+
+  const maze   = new Maze(10,10,40),
+        rAgent = new RuleAgent(workspace),
+        qAgent = new QAgent([0,1,2]);
+  let mode='rules', loopId=null;
+
+  const byId = id=>document.getElementById(id);
+  byId('modeBtn').onclick = () => {
+    mode = mode==='rules'?'ai':'rules';
+    byId('modeBtn').textContent = `Mode: ${mode==='rules'?'Rules':'AI'}`;
+  };
+  byId('bfsBtn').onclick = () => { maze.draw(maze.bfsPath()); };
+  byId('trainBtn').onclick = () => { qAgent.train(maze,1000); alert('AI trained!'); };
+  byId('resetBtn').onclick = () => { clearInterval(loopId); maze.reset(); maze.draw(); };
+  byId('stopBtn').onclick = () => { clearInterval(loopId); };
+  byId('startBtn').onclick = () => {
+    clearInterval(loopId);
+    maze.reset(); maze.draw();
+    if(mode==='rules') rAgent.reset();
+    loopId = setInterval(() => {
+      let action=null;
+      if(mode==='rules'){
+        action = rAgent.step(maze.getSensors());
+        if(rAgent.done()) clearInterval(loopId);
+      } else {
+        action = qAgent.choose(`${maze.agent.x},${maze.agent.y},${maze.agent.dir}`);
+        if(maze.step(action)) clearInterval(loopId);
+      }
+      if(action!==null) maze.step(action);
+      maze.draw();
+    },300);
+  };
+  byId('stepBtn').onclick = () => {
+    clearInterval(loopId);
+    if(mode==='rules'){
+      if(rAgent.done()) rAgent.reset();
+      const a = rAgent.step(maze.getSensors());
+      if(a!==null) maze.step(a);
+    } else {
+      const a = qAgent.choose(`${maze.agent.x},${maze.agent.y},${maze.agent.dir}`);
+      if(a!==null) maze.step(a);
+    }
+    maze.draw();
+  };
+
+  maze.draw();
+  </script>
+</body>
+</html>

--- a/maze_ml_activity.py
+++ b/maze_ml_activity.py
@@ -1,0 +1,120 @@
+import random
+from collections import deque
+from typing import List, Tuple
+
+class Maze:
+    def __init__(self, width: int = 6, height: int = 6, obstacle_ratio: float = 0.2):
+        self.width = width
+        self.height = height
+        self.start = (0, 0)
+        self.goal = (width - 1, height - 1)
+        self.obstacles = self._generate_obstacles(obstacle_ratio)
+
+    def _generate_obstacles(self, ratio: float) -> List[Tuple[int, int]]:
+        obstacles = []
+        for x in range(self.width):
+            for y in range(self.height):
+                if (x, y) not in [self.start, self.goal] and random.random() < ratio:
+                    obstacles.append((x, y))
+        return obstacles
+
+    def is_free(self, pos: Tuple[int, int]) -> bool:
+        x, y = pos
+        if not (0 <= x < self.width and 0 <= y < self.height):
+            return False
+        return pos not in self.obstacles
+
+class RuleSolver:
+    """Breadth-first search for a path."""
+    def __init__(self, maze: Maze):
+        self.maze = maze
+
+    def solve(self) -> List[Tuple[int, int]]:
+        start, goal = self.maze.start, self.maze.goal
+        queue = deque([(start, [start])])
+        visited = {start}
+        while queue:
+            (x, y), path = queue.popleft()
+            if (x, y) == goal:
+                return path
+            for dx, dy in [(-1,0),(1,0),(0,-1),(0,1)]:
+                nx, ny = x + dx, y + dy
+                new_pos = (nx, ny)
+                if new_pos not in visited and self.maze.is_free(new_pos):
+                    visited.add(new_pos)
+                    queue.append((new_pos, path + [new_pos]))
+        return []
+
+class QLearningAgent:
+    def __init__(self, maze: Maze, episodes: int = 500, alpha: float = 0.1, gamma: float = 0.9, epsilon: float = 0.2):
+        self.maze = maze
+        self.q = {
+            (x, y): [0, 0, 0, 0] for x in range(maze.width) for y in range(maze.height)
+        }
+        self.episodes = episodes
+        self.alpha = alpha
+        self.gamma = gamma
+        self.epsilon = epsilon
+        self.actions = [(-1,0),(1,0),(0,-1),(0,1)]
+
+    def _choose_action(self, state: Tuple[int, int]) -> int:
+        if random.random() < self.epsilon:
+            return random.randint(0, 3)
+        q_values = self.q[state]
+        return q_values.index(max(q_values))
+
+    def _step(self, state: Tuple[int, int], action_idx: int) -> Tuple[Tuple[int, int], float, bool]:
+        dx, dy = self.actions[action_idx]
+        new_state = (state[0] + dx, state[1] + dy)
+        if not self.maze.is_free(new_state):
+            reward = -1
+            new_state = state
+            done = False
+        elif new_state == self.maze.goal:
+            reward = 10
+            done = True
+        else:
+            reward = -0.1
+            done = False
+        return new_state, reward, done
+
+    def train(self):
+        for _ in range(self.episodes):
+            state = self.maze.start
+            done = False
+            while not done:
+                action = self._choose_action(state)
+                next_state, reward, done = self._step(state, action)
+                best_next = max(self.q[next_state])
+                self.q[state][action] += self.alpha * (reward + self.gamma * best_next - self.q[state][action])
+                state = next_state
+
+    def run(self) -> List[Tuple[int, int]]:
+        state = self.maze.start
+        path = [state]
+        steps = 0
+        while state != self.maze.goal and steps < 100:
+            action = self._choose_action(state)
+            next_state, _, _ = self._step(state, action)
+            if next_state == state:
+                break
+            path.append(next_state)
+            state = next_state
+            steps += 1
+        return path
+
+if __name__ == "__main__":
+    random.seed(42)
+    maze = Maze(width=6, height=6, obstacle_ratio=0.2)
+    print("Maze obstacles:", maze.obstacles)
+
+    rule_solver = RuleSolver(maze)
+    rule_path = rule_solver.solve()
+    print("\nChemin trouvé par règle:")
+    print(rule_path)
+
+    agent = QLearningAgent(maze)
+    agent.train()
+    ai_path = agent.run()
+    print("\nChemin trouvé par apprentissage:")
+    print(ai_path)


### PR DESCRIPTION
## Summary
- add `maze_activity.html` with Blockly interface for rule-based and Q-learning maze solving
- mention HTML demo in README

## Testing
- `python -m py_compile maze_ml_activity.py`


------
https://chatgpt.com/codex/tasks/task_e_6882577b3be083318385f388073aa020