### PR TITLE
Reorganize maze controls

### DIFF
--- a/maze_activity.html
+++ b/maze_activity.html
@@ -22,12 +22,12 @@
   <div id="rightPanel">
     <canvas id="mazeCanvas"></canvas>
     <div id="controls">
-      <button id="bfsBtn">Solve BFS</button>
-      <button id="trainBtn">Train AI</button>
       <button id="startBtn">Start</button>
-      <button id="stepBtn">Step</button>
       <button id="stopBtn">Stop</button>
+      <button id="stepBtn">Step</button>
       <button id="resetBtn">Reset</button>
+      <button id="trainBtn">Train AI</button>
+      <button id="pathBtn">Show Path</button>
       <button id="modeBtn">Mode: Rules</button>
     </div>
   </div>
@@ -268,14 +268,6 @@
   let mode='rules', loopId=null;
 
   const byId = id=>document.getElementById(id);
-  byId('modeBtn').onclick = () => {
-    mode = mode==='rules'?'ai':'rules';
-    byId('modeBtn').textContent = `Mode: ${mode==='rules'?'Rules':'AI'}`;
-  };
-  byId('bfsBtn').onclick = () => { maze.draw(maze.bfsPath()); };
-  byId('trainBtn').onclick = () => { qAgent.train(maze,1000); alert('AI trained!'); };
-  byId('resetBtn').onclick = () => { clearInterval(loopId); maze.reset(); maze.draw(); };
-  byId('stopBtn').onclick = () => { clearInterval(loopId); };
   byId('startBtn').onclick = () => {
     clearInterval(loopId);
     maze.reset(); maze.draw();
@@ -293,6 +285,7 @@
       maze.draw();
     },300);
   };
+  byId('stopBtn').onclick = () => { clearInterval(loopId); };
   byId('stepBtn').onclick = () => {
     clearInterval(loopId);
     if(mode==='rules'){
@@ -304,6 +297,13 @@
       if(a!==null) maze.step(a);
     }
     maze.draw();
+  };
+  byId('resetBtn').onclick = () => { clearInterval(loopId); maze.reset(); maze.draw(); };
+  byId('trainBtn').onclick = () => { qAgent.train(maze,1000); alert('AI trained!'); };
+  byId('pathBtn').onclick = () => { maze.draw(maze.bfsPath()); };
+  byId('modeBtn').onclick = () => {
+    mode = mode==='rules'?'ai':'rules';
+    byId('modeBtn').textContent = `Mode: ${mode==='rules'?'Rules':'AI'}`;
   };
 
   maze.draw();


### PR DESCRIPTION
## Summary
- tweak button order for a clearer workflow
- rename the BFS control to "Show Path"
- update JavaScript handlers for new IDs and ordering

## Testing
- `python -m py_compile maze_ml_activity.py`

------
https://chatgpt.com/codex/tasks/task_e_68826bee55bc833184fe0c00bba8c114