### PR TITLE
Fix robot reset

### DIFF
--- a/maze_activity.html
+++ b/maze_activity.html
@@ -189,8 +189,15 @@
             // Reset robot to start facing right
             robot.x=0; robot.y=0; robot.dir=1;
             drawGrid();
+            // give the reset state a moment to render
+            await new Promise(r => setTimeout(r, 300));
             const start = workspace.getTopBlocks(true).find(b=>b.type==='start_block');
-            if (!start) { alert('Add a Start block.'); return; }
+            if (!start) {
+                alert('Add a Start block.');
+                isRunning = false;
+                runButton.disabled = false;
+                return;
+            }
             try {
                 Blockly.JavaScript.init(workspace);
                 const code = Blockly.JavaScript.blockToCode(start);


### PR DESCRIPTION
## Summary
- delay running the program a moment after resetting the robot so the start position shows consistently
- reset running state if no Start block is found
- add missing newline at end of maze file

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_688a1c12676883318c4e97fd4f44d598