### PR TITLE
Fix double execution by disabling Run button during run

### DIFF
--- a/maze_activity.html
+++ b/maze_activity.html
@@ -237,7 +237,12 @@
                 shouldStop = true;
                 restartAfterStop = true;
             } else {
-                runProgram();
+                runButton.disabled = true;
+                try {
+                    await runProgram();
+                } finally {
+                    runButton.disabled = false;
+                }
 
             }
         });


### PR DESCRIPTION
## Summary
- disable Run button while the Blockly program is running to prevent multiple concurrent runs

## Testing
- `node -e "console.log('node version', process.version)"`


------
https://chatgpt.com/codex/tasks/task_e_688a24898964833192e37190a9034ff4