### PR TITLE
Stop program and reset behavior

### DIFF
--- a/maze_activity.html
+++ b/maze_activity.html
@@ -170,6 +170,15 @@
         let isRunning = false;
         let shouldStop = false;
         let restartAfterStop = false;
+        let goalReached = false;
+
+        function resetBoard() {
+            maze = level === 2 ? generateSolvableMaze() : JSON.parse(JSON.stringify(staticMaze));
+            robot.x = 0;
+            robot.y = 0;
+            robot.dir = 1;
+            drawGrid();
+        }
 
         function updateLevelDisplay() {
             levelDisplay.textContent = 'Level: ' + level;
@@ -287,6 +296,11 @@
                 robot.x = nx; robot.y = ny;
             }
             drawGrid();
+            if (robot.x === 7 && robot.y === 7) {
+                goalReached = true;
+                shouldStop = true;
+                throw 'goal';
+            }
             await new Promise(r => setTimeout(r, 300));
             if (shouldStop) throw 'stopped';
         }
@@ -312,6 +326,7 @@
         async function runProgram() {
             do {
                 restartAfterStop = false;
+                goalReached = false;
                 isRunning = true;
                 runButton.textContent = 'Stop Program';
                 shouldStop = false;
@@ -335,23 +350,35 @@
                     const run = outer(moveForward, turnLeft, turnRight);
                     await run();
                 } catch(err) {
-                    if (err !== 'stopped') {
+                    if (err === 'goal') {
+                        // reached the goal; wait for user to reset
+                    } else if (err !== 'stopped') {
                         console.error(err);
                         alert('Runtime error; see console.');
 
                     }
                 } finally {
-                    isRunning = false;
-                    runButton.textContent = 'Run Program';
+                    if (goalReached) {
+                        // keep button as Stop Program so user can reset
+                        shouldStop = false;
+                    } else {
+                        isRunning = false;
+                        runButton.textContent = 'Run Program';
+                        resetBoard();
+                    }
                 }
             } while (restartAfterStop);
         }
 
 
         runButton.addEventListener('click', async ()=>{
-            if (isRunning) {
+            if (goalReached) {
+                resetBoard();
+                goalReached = false;
+                isRunning = false;
+                runButton.textContent = 'Run Program';
+            } else if (isRunning) {
                 shouldStop = true;
-                
             } else {
                 runButton.disabled = true;
                 try {


### PR DESCRIPTION
## Summary
- add goalReached flag and a helper to reset the maze
- detect reaching the goal in `moveForward`
- keep program paused at the goal until the user presses stop
- reset the board when stopping manually or after reaching the goal

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_688a3e899e9883318552cb86128f354b