### PR TITLE
Fix run button disabling

### DIFF
--- a/maze_activity.html
+++ b/maze_activity.html
@@ -351,14 +351,9 @@
         runButton.addEventListener('click', async ()=>{
             if (isRunning) {
                 shouldStop = true;
-                
+
             } else {
-                runButton.disabled = true;
-                try {
-                    await runProgram();
-                } finally {
-                    runButton.disabled = false;
-                }
+                await runProgram();
 
             }
         });


### PR DESCRIPTION
## Summary
- allow the `Run Program` button to be clicked while a program is running so it can be used to stop execution

## Testing
- `n/a`

------
https://chatgpt.com/codex/tasks/task_e_688a43c29dd083318cab7e4337048bc4