### PR TITLE
Fix run button disabling

### DIFF
--- a/maze_activity.html
+++ b/maze_activity.html
@@ -323,7 +323,12 @@
                 drawGrid();
                 await new Promise(r => setTimeout(r, 300));
                 const start = workspace.getTopBlocks(true).find(b=>b.type==='start_block');
-                if (!start) { alert('Add a Start block.'); break; }
+                if (!start) {
+                    alert('Add a Start block.');
+                    isRunning = false;
+                    runButton.textContent = 'Run Program';
+                    break;
+                }
                 try {
                     Blockly.JavaScript.init(workspace);
                     const code = Blockly.JavaScript.blockToCode(start);
@@ -350,15 +355,11 @@
 
         runButton.addEventListener('click', async ()=>{
             if (isRunning) {
+                if (shouldStop) restartAfterStop = true;
                 shouldStop = true;
-                
+
             } else {
-                runButton.disabled = true;
-                try {
-                    await runProgram();
-                } finally {
-                    runButton.disabled = false;
-                }
+                await runProgram();
 
             }
         });


### PR DESCRIPTION
## Summary
- allow restart requests while program is stopping
- reset state when run is invoked without a Start block

## Testing
- `n/a`


------
https://chatgpt.com/codex/tasks/task_e_688a43c29dd083318cab7e4337048bc4