### PR TITLE
Implement simple Q-learning AI

### DIFF
--- a/maze_activity.html
+++ b/maze_activity.html
@@ -67,17 +67,36 @@
             font-size: 16px;
             cursor: pointer;
         }
+        #chartCanvas {
+            width: 90%;
+            max-width: 600px;
+            height: 50px;
+            background: #fff;
+            box-shadow: 0 0 4px rgba(0,0,0,0.1);
+            margin-top: 5px;
+        }
+        #modeButton {
+            padding: 5px 10px;
+            font-size: 14px;
+            cursor: pointer;
+        }
+        #speedSlider {
+            width: 100px;
+        }
     </style>
 </head>
 <body>
     <div id="blocklyArea"></div>
     <div id="visualArea">
         <canvas id="gridCanvas"></canvas>
+        <canvas id="chartCanvas" style="width:90%;max-width:600px;height:50px;"></canvas>
         <button id="runButton">Run Program</button>
         <div id="levelControls">
             <button id="levelDownButton">Level -</button>
             <span id="levelDisplay"></span>
             <button id="levelUpButton">Level +</button>
+            <button id="modeButton">Mode: Blockly</button>
+            <label>Speed:<input type="range" id="speedSlider" min="2" max="60" value="20"></label>
         </div>
     </div>
 
@@ -158,22 +177,58 @@
         let level = 1;
         // Start facing right instead of up
         const robot = { x: 0, y: 0, dir: 1 };
+        let trail = [];
+
+        /* Q-learning state */
+        const qTable = Array.from({length:256}, () => [0,0,0]);
+        let eps = 1.0;
+        const alpha = 0.5;
+        const gamma = 0.9;
+        let episodes = 0;
+        let episodeLengths = [];
+        let training = false;
 
         /* Canvas setup */
         const canvas = document.getElementById('gridCanvas');
         const ctx = canvas.getContext('2d');
         const runButton = document.getElementById('runButton');
+        const modeButton = document.getElementById('modeButton');
+        const speedSlider = document.getElementById('speedSlider');
+        const chartCanvas = document.getElementById('chartCanvas');
+        const chartCtx = chartCanvas.getContext('2d');
         const levelDisplay = document.getElementById('levelDisplay');
         const levelUpButton = document.getElementById('levelUpButton');
         const levelDownButton = document.getElementById('levelDownButton');
         let tileSize;
+        let speed = parseInt(speedSlider.value);
         let isRunning = false;
         let shouldStop = false;
         let restartAfterStop = false;
+        let mode = 'Blockly';
+
+        speedSlider.addEventListener('input', () => {
+            speed = parseInt(speedSlider.value);
+        });
 
         function updateLevelDisplay() {
             levelDisplay.textContent = 'Level: ' + level;
         }
+
+        function updateModeDisplay() {
+            modeButton.textContent = 'Mode: ' + mode;
+            if (mode === 'Blockly') runButton.textContent = 'Run Program';
+            else if (mode === 'AI Train') runButton.textContent = training ? 'Stop AI' : 'Start AI Training';
+            else runButton.textContent = 'Run AI';
+        }
+
+        modeButton.addEventListener('click', () => {
+            if (mode === 'Blockly') mode = 'AI Train';
+            else if (mode === 'AI Train') mode = 'AI Run';
+            else mode = 'Blockly';
+            if (training && mode !== 'AI Train') training = false;
+            updateModeDisplay();
+        });
+        updateModeDisplay();
         levelUpButton.addEventListener('click', () => {
             if (level < 2) {
                 level++;
@@ -230,6 +285,10 @@
                     ctx.strokeRect(x*tileSize, y*tileSize, tileSize, tileSize);
                 }
             }
+            for (const p of trail) {
+                ctx.fillStyle = p.color;
+                ctx.fillRect(p.x*tileSize+tileSize*0.3, p.y*tileSize+tileSize*0.3, tileSize*0.4, tileSize*0.4);
+            }
             // goal
             ctx.fillStyle = 'green';
             ctx.beginPath();
@@ -249,6 +308,15 @@
             ctx.fillStyle = 'red';
             ctx.fill();
             ctx.restore();
+
+            const q = qTable[encodeState(robot)];
+            const minV = Math.min(...q), maxV = Math.max(...q);
+            const range = maxV - minV || 1;
+            const bx = robot.x*tileSize, by = robot.y*tileSize;
+            ctx.fillStyle = 'rgba(0,0,255,0.6)';
+            ctx.fillRect(bx+tileSize/2-2, by+tileSize/2 - ((q[0]-minV)/range)*(tileSize/3), 4, ((q[0]-minV)/range)*(tileSize/3));
+            ctx.fillRect(bx+tileSize/2 - ((q[1]-minV)/range)*(tileSize/3), by+tileSize/2-2, ((q[1]-minV)/range)*(tileSize/3), 4);
+            ctx.fillRect(bx+tileSize/2, by+tileSize/2-2, ((q[2]-minV)/range)*(tileSize/3), 4);
         }
 
         async function goalAnimation() {
@@ -295,8 +363,9 @@
 }
 
 
-        async function moveForward() {
+        async function moveForward(color) {
             if (shouldStop) throw 'stopped';
+            if (color) trail.push({x: robot.x, y: robot.y, color});
             const dx = [0, 1, 0, -1], dy = [-1, 0, 1, 0];
             const nx = robot.x + dx[robot.dir], ny = robot.y + dy[robot.dir];
             if (nx>=0 && ny>=0 && nx<8 && ny<8 && maze[ny][nx]===0) {
@@ -311,14 +380,16 @@
             await new Promise(r => setTimeout(r, 300));
             if (shouldStop) throw 'stopped';
         }
-        async function turnLeft() {
+        async function turnLeft(color) {
             if (shouldStop) throw 'stopped';
+            if (color) trail.push({x: robot.x, y: robot.y, color});
             robot.dir=(robot.dir+3)%4; drawGrid();
             await new Promise(r=>setTimeout(r,300));
             if (shouldStop) throw 'stopped';
         }
-        async function turnRight() {
+        async function turnRight(color) {
             if (shouldStop) throw 'stopped';
+            if (color) trail.push({x: robot.x, y: robot.y, color});
             robot.dir=(robot.dir+1)%4; drawGrid();
             await new Promise(r=>setTimeout(r,300));
             if (shouldStop) throw 'stopped';
@@ -328,6 +399,90 @@
             const dx = [0, 1, 0, -1], dy = [-1, 0, 1, 0];
             const nx = robot.x + dx[robot.dir], ny = robot.y + dy[robot.dir];
             return !(nx>=0 && ny>=0 && nx<8 && ny<8 && maze[ny][nx]===0);
+        }
+
+        function encodeState(r) {
+            return r.y * 32 + r.x * 4 + r.dir;
+        }
+        function randomAct() { return Math.floor(Math.random()*3); }
+        function argMaxQ(s) {
+            const q = qTable[s];
+            return q.indexOf(Math.max(...q));
+        }
+        function maxQ(s) { return Math.max(...qTable[s]); }
+
+        function atGoal() { return robot.x===7 && robot.y===7; }
+
+        async function stepAction(a, color) {
+            if (a===0) await moveForward(color);
+            else if (a===1) await turnLeft(color);
+            else await turnRight(color);
+            return atGoal() ? 0 : -1;
+        }
+
+        function resetMaze() {
+            maze = level === 2 ? generateSolvableMaze() : JSON.parse(JSON.stringify(staticMaze));
+            robot.x=0; robot.y=0; robot.dir=1; trail=[];
+            drawGrid();
+        }
+
+        function drawChart() {
+            const w = chartCanvas.width = chartCanvas.getBoundingClientRect().width * devicePixelRatio;
+            const h = chartCanvas.height = chartCanvas.getBoundingClientRect().height * devicePixelRatio;
+            chartCtx.scale(devicePixelRatio, devicePixelRatio);
+            chartCtx.clearRect(0,0,w,h);
+            chartCtx.strokeStyle = 'black';
+            chartCtx.beginPath();
+            episodeLengths.forEach((len,i)=>{
+                const x = i/(episodeLengths.length-1||1)*w/devicePixelRatio;
+                const y = h/devicePixelRatio - (len/128)*(h/devicePixelRatio);
+                if(i===0) chartCtx.moveTo(x,y); else chartCtx.lineTo(x,y);
+            });
+            chartCtx.stroke();
+        }
+
+        async function trainEpisode(maxSteps=128) {
+            resetMaze();
+            for (let t=0; t<maxSteps; t++) {
+                const s = encodeState(robot);
+                let a, exploring=false;
+                if (Math.random()<eps) { exploring=true; a=randomAct(); } else a=argMaxQ(s);
+                const reward = await stepAction(a, exploring? 'blue':'orange');
+                const s2 = encodeState(robot);
+                qTable[s][a] += alpha*(reward + gamma*maxQ(s2) - qTable[s][a]);
+                drawGrid();
+                if (atGoal()) return t+1;
+            }
+            return maxSteps;
+        }
+
+        async function runGreedyEpisode(maxSteps=128) {
+            resetMaze();
+            for (let t=0; t<maxSteps; t++) {
+                const s = encodeState(robot);
+                const a = argMaxQ(s);
+                await stepAction(a, 'orange');
+                drawGrid();
+                if (atGoal()) return t+1;
+            }
+            return maxSteps;
+        }
+
+        async function trainingLoop() {
+            training = true;
+            updateModeDisplay();
+            while (training) {
+                const len = await trainEpisode();
+                episodeLengths.push(len);
+                episodes++;
+                eps = Math.max(0.1, 1 - 0.9*episodes/200);
+                drawChart();
+                await new Promise(r=>setTimeout(r, 1000/speed));
+            }
+        }
+
+        async function runAIOnce() {
+            await runGreedyEpisode();
         }
 
         async function runProgram() {
@@ -369,19 +524,29 @@
                 } finally {
                     isRunning = false;
                     runButton.textContent = 'Run Program';
+                    updateModeDisplay();
                 }
             } while (restartAfterStop);
         }
 
 
         runButton.addEventListener('click', async ()=>{
-            if (isRunning) {
-                if (shouldStop) restartAfterStop = true;
-                shouldStop = true;
-
+            if (mode === 'Blockly') {
+                if (isRunning) {
+                    if (shouldStop) restartAfterStop = true;
+                    shouldStop = true;
+                } else {
+                    await runProgram();
+                }
+            } else if (mode === 'AI Train') {
+                if (training) {
+                    training = false;
+                } else {
+                    trainingLoop();
+                }
+                updateModeDisplay();
             } else {
-                await runProgram();
-
+                await runAIOnce();
             }
         });
 


### PR DESCRIPTION
## Summary
- add controls for AI modes and speed
- implement Q-learning state and helper functions
- show agent trail and Q-value bars on the canvas
- support training and greedy run modes with chart display

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_688a5b1e46908331a296d985e830936a