### PR TITLE
Update controls for AI/Blockly modes

### DIFF
--- a/maze_activity.html
+++ b/maze_activity.html
@@ -75,6 +75,13 @@
             cursor: pointer;
         }
 
+        #trainButton {
+            margin-top: 5px;
+            padding: 5px 10px;
+            font-size: 14px;
+            cursor: pointer;
+        }
+
         #chartCanvas {
             width: 90%;
             max-width: 600px;
@@ -99,13 +106,14 @@
         <canvas id="gridCanvas"></canvas>
         <canvas id="chartCanvas" style="width:90%;max-width:600px;height:50px;"></canvas>
         <button id="runButton">Run Program</button>
+        <button id="trainButton">Start Training</button>
         <button id="batchButton">Train 100</button>
         <div id="levelControls">
             <button id="levelDownButton">Level -</button>
             <span id="levelDisplay"></span>
             <button id="levelUpButton">Level +</button>
             <button id="modeButton">Mode: Blockly</button>
-            <label>Speed:<input type="range" id="speedSlider" min="2" max="60" value="20"></label>
+            <label id="speedLabel">Speed:<input type="range" id="speedSlider" min="2" max="60" value="20"></label>
         </div>
     </div>
 
@@ -201,11 +209,12 @@
         const canvas = document.getElementById('gridCanvas');
         const ctx = canvas.getContext('2d');
         const runButton = document.getElementById('runButton');
-
+        const trainButton = document.getElementById('trainButton');
         const batchButton = document.getElementById('batchButton');
 
         const modeButton = document.getElementById('modeButton');
         const speedSlider = document.getElementById('speedSlider');
+        const speedLabel = document.getElementById('speedLabel');
         const chartCanvas = document.getElementById('chartCanvas');
         const chartCtx = chartCanvas.getContext('2d');
         const levelDisplay = document.getElementById('levelDisplay');
@@ -228,16 +237,29 @@
 
         function updateModeDisplay() {
             modeButton.textContent = 'Mode: ' + mode;
-            if (mode === 'Blockly') runButton.textContent = 'Run Program';
-            else if (mode === 'AI Train') runButton.textContent = training ? 'Stop AI' : 'Start AI Training';
-            else runButton.textContent = 'Run AI';
+            if (mode === 'Blockly') {
+                runButton.textContent = 'Run Program';
+                trainButton.style.display = 'none';
+                batchButton.style.display = 'none';
+                chartCanvas.style.display = 'none';
+                speedLabel.style.display = 'none';
+            } else {
+                runButton.textContent = 'Run AI';
+                trainButton.style.display = '';
+                batchButton.style.display = '';
+                chartCanvas.style.display = '';
+                speedLabel.style.display = '';
+                trainButton.textContent = training ? 'Stop Training' : 'Start Training';
+            }
         }
 
         modeButton.addEventListener('click', () => {
-            if (mode === 'Blockly') mode = 'AI Train';
-            else if (mode === 'AI Train') mode = 'AI Run';
-            else mode = 'Blockly';
-            if (training && mode !== 'AI Train') training = false;
+            if (mode === 'Blockly') {
+                mode = 'AI';
+            } else {
+                mode = 'Blockly';
+                if (training) training = false;
+            }
             updateModeDisplay();
         });
         updateModeDisplay();
@@ -595,23 +617,23 @@
                 } else {
                     await runProgram();
                 }
-            } else if (mode === 'AI Train') {
-                if (training) {
-                    training = false;
-                } else {
-                    trainingLoop();
-                }
-                updateModeDisplay();
             } else {
                 await runAIOnce();
-
             }
         });
 
-        batchButton.addEventListener('click', async () => {
-            if (mode === 'AI Train' && !training) {
-                await runFastEpisodes(100);
+        trainButton.addEventListener('click', async () => {
+            if (training) {
+                training = false;
+            } else {
+                trainingLoop();
+            }
+            updateModeDisplay();
+        });
 
+        batchButton.addEventListener('click', async () => {
+            if (mode === 'AI' && !training) {
+                await runFastEpisodes(100);
             }
         });
 


### PR DESCRIPTION
## Summary
- add train button and speed label element
- hide AI controls when in Blockly mode
- simplify mode switcher to two modes
- add event handlers for training and AI runs

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_688a658956308331a0339e6942511534