### PR TITLE
Enable URL-based Blockly state sharing

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,6 +8,7 @@
     <script src="https://unpkg.com/blockly/blockly.min.js"></script>
     
     <script src="https://unpkg.com/blockly/javascript_compressed.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/lz-string@1.4.4/libs/lz-string.min.js"></script>
     
     <style>
       
@@ -186,6 +187,31 @@
                 ]
             }
         });
+
+        // Persist workspace state in the URL for easy sharing
+        function updateURLFromWorkspace() {
+            const xml = Blockly.Xml.domToText(Blockly.Xml.workspaceToDom(workspace));
+            const comp = LZString.compressToEncodedURIComponent(xml);
+            history.replaceState(null, '', '#' + comp);
+        }
+
+        function loadWorkspaceFromURL() {
+            const hash = location.hash.slice(1);
+            if (!hash) return;
+            try {
+                const xmlText = LZString.decompressFromEncodedURIComponent(hash);
+                if (xmlText) {
+                    const dom = Blockly.Xml.textToDom(xmlText);
+                    Blockly.Xml.clearWorkspaceAndLoadFromXml(dom, workspace);
+                }
+            } catch (e) {
+                console.warn('Failed to load workspace from URL:', e);
+            }
+        }
+
+        window.addEventListener('popstate', loadWorkspaceFromURL);
+        loadWorkspaceFromURL();
+        workspace.addChangeListener(() => updateURLFromWorkspace());
 
         /* Maze & robot state */
         const staticMaze = [


### PR DESCRIPTION
## Summary
- add `lz-string` compression script
- keep the Blockly workspace in the URL hash

## Testing
- `npx eslint index.html` *(fails: ESLint couldn't find a config)*
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688a71f8ea048331b747a763e2a36e71