### PR TITLE
Fix Blockly state sharing in URL

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,6 +8,7 @@
     <script src="https://unpkg.com/blockly/blockly.min.js"></script>
     
     <script src="https://unpkg.com/blockly/javascript_compressed.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/lz-string@1.4.4/libs/lz-string.min.js"></script>
     
     <style>
       
@@ -186,6 +187,32 @@
                 ]
             }
         });
+
+        // Persist workspace state in the URL for easy sharing
+        function updateURLFromWorkspace() {
+            const xml = Blockly.Xml.domToText(Blockly.Xml.workspaceToDom(workspace));
+            const comp = LZString.compressToEncodedURIComponent(xml);
+            location.hash = comp;
+        }
+
+        function loadWorkspaceFromURL() {
+            const hash = location.hash.slice(1);
+            if (!hash) return;
+            try {
+                const xmlText = LZString.decompressFromEncodedURIComponent(hash);
+                if (xmlText) {
+                    const dom = Blockly.Xml.textToDom(xmlText);
+                    Blockly.Xml.clearWorkspaceAndLoadFromXml(dom, workspace);
+                }
+            } catch (e) {
+                console.warn('Failed to load workspace from URL:', e);
+            }
+        }
+
+        window.addEventListener('popstate', loadWorkspaceFromURL);
+        window.addEventListener('hashchange', loadWorkspaceFromURL);
+        loadWorkspaceFromURL();
+        workspace.addChangeListener(() => updateURLFromWorkspace());
 
         /* Maze & robot state */
         const staticMaze = [


### PR DESCRIPTION
## Summary
- load workspace when the hash changes
- update the URL hash directly when workspace changes

## Testing
- `npx eslint index.html` *(fails: ESLint couldn't find an eslint.config file)*
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_688a71f8ea048331b747a763e2a36e71